### PR TITLE
SingleSpaceBeforeFirstArg been renamed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false


### PR DESCRIPTION
Error: The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg. 
(obsolete configuration found in /home/travis/build/bloomberg/zookeeper-cookbook/.rubocop.yml, please update it)
RuboCop failed!
